### PR TITLE
fix: remove cache:pnpm and update Node to 24

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: "pnpm"
+          node-version: 24
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Install dependencies


### PR DESCRIPTION
Remove the cache: pnpm option from setup-node step which causes a chicken-and-egg failure (pnpm not found), and update Node from 18 to 24.