### PR TITLE
fix: use .npmrc for pnpm v10 onlyBuiltDependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 package-manager-strict=false
-onlyBuiltDependencies[]="@swc/core"
-onlyBuiltDependencies[]="esbuild"
+onlyBuiltDependencies[]=@swc/core
+onlyBuiltDependencies[]=esbuild

--- a/package.json
+++ b/package.json
@@ -41,12 +41,6 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild"
-    ]
-  },
   "browserslist": [
     ">0.2%",
     "not dead",


### PR DESCRIPTION
pnpm v10 moved settings out of package.json into .npmrc. The onlyBuiltDependencies config allows @swc/core and esbuild build scripts.