### PR TITLE
fix: use kebab-case in .npmrc for pnpm v10

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 package-manager-strict=false
-onlyBuiltDependencies[]=@swc/core
-onlyBuiltDependencies[]=esbuild
+only-built-dependencies[]=@swc/core
+only-built-dependencies[]=esbuild


### PR DESCRIPTION
pnpm v10 expects kebab-case setting names in .npmrc.