### PR TITLE
fix: remove pnpm-workspace.yaml, rely on .npmrc only

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-onlyBuiltDependencies:
-  - "@swc/core"
-  - esbuild


### PR DESCRIPTION
Remove the workspace config and let .npmrc handle onlyBuiltDependencies.