### PR TITLE
fix: allow pnpm dependency builds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-package-manager-strict=false
-only-built-dependencies[]=@swc/core
-only-built-dependencies[]=esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  "@swc/core": true
+  esbuild: true


### PR DESCRIPTION
Update pnpm dependency build approvals for pnpm 11 by moving the allowlist from .npmrc to pnpm-workspace.yaml using allowBuilds. This fixes the GitHub Pages install failure caused by ERR_PNPM_IGNORED_BUILDS for @swc/core and esbuild.